### PR TITLE
Added Section and Priority to Debian control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,11 @@
 Source: r8125-dkms
 Maintainer: Bas Vermeulen <bvermeul@blackstar.nl>
+Section: net
+Priority: optional
 Build-Depends: debhelper (>= 9), dkms
 
 Package: r8125-dkms
 Architecture: all
+Priority: optional
 Depends: ${misc:Depends}
 Description: DKMS source for the RTL8125/Killer Ethernet E3000 network driver


### PR DESCRIPTION
Section and priority seem to be mandatory, at least `reprepro` doesn't accept packages without them.
Adding them is the easiest way to fix the issue.